### PR TITLE
Issue 2 - Removed developer’s GOPATH from stack trace output

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -13,7 +13,8 @@ BUILD_TIMESTAMP=`date +%FT%T%z`
 BUILD_DATE=`date +"%Y-%m-%d"`
 
 # Setup the -ldflags option for go build here
-LDFLAGS=-ldflags "-w -s -X main.Version=${VERSION} -X main.Date=${BUILD_DATE} -X main.ExecName=${BINARY} -X main.Build=${BUILD_TIMESTAMP}"
+LDFLAGS=-ldflags "-w -s -X main.Version=${VERSION} -X main.Date=${BUILD_DATE} -X main.ExecName=${BINARY} -X main.Build=${BUILD_TIMESTAMP}" 
+GCFLAGS=-gcflags=-trimpath=${GOPATH} -asmflags=-trimpath=${GOPATH}
 
 #
 # Cleans and builds everything
@@ -43,15 +44,15 @@ windows: out/windows package-windows
 #
 out/macos: dependencies
 	$(info macos:   building executable)
-	@GOOS="darwin" GOARCH="amd64" go build ${LDFLAGS} -o ${OUTPUT_DIR}/macos/strongback ${WHAT}
+	@GOOS="darwin" GOARCH="amd64" go build ${LDFLAGS} ${GCFLAGS} -o ${OUTPUT_DIR}/macos/strongback ${WHAT}
 
 out/linux: dependencies
 	$(info Linux:   building executable)
-	@GOOS="linux" GOARCH="amd64" go build ${LDFLAGS} -o ${OUTPUT_DIR}/linux/strongback ${WHAT}
+	@GOOS="linux" GOARCH="amd64" go build ${LDFLAGS} ${GCFLAGS} -o ${OUTPUT_DIR}/linux/strongback ${WHAT}
 
 out/windows: dependencies
 	$(info Windows: building executable)
-	@GOOS="windows" GOARCH="386" go build ${LDFLAGS} -o ${OUTPUT_DIR}/windows/strongback.exe ${WHAT}
+	@GOOS="windows" GOARCH="386" go build ${LDFLAGS} ${GCFLAGS} -o ${OUTPUT_DIR}/windows/strongback.exe ${WHAT}
 
 .PHONY: test
 test:

--- a/Makefile
+++ b/Makefile
@@ -17,15 +17,18 @@ LDFLAGS=-ldflags "-w -s -X main.Version=${VERSION} -X main.Date=${BUILD_DATE} -X
 GCFLAGS=-gcflags=-trimpath=${GOPATH} -asmflags=-trimpath=${GOPATH}
 
 #
+# Make everything
+#
+.PHONY: all
+all: macos linux windows
+
+#
 # Cleans and builds everything
 #
 .PHONY: clean
 clean:
 	$(info Cleaning 'out' directory)
 	@rm -rf ${OUTPUT_DIR}
-
-.PHONY: all
-all: macos linux windows
 
 #
 # Packaging for each OS


### PR DESCRIPTION
Used the `-gcflags` and `-asmflags` compiler options to remove the `GOPATH` from the source file paths shown by a stack trace.

Fixes #2 