### PR TITLE
Fixed the `new-project` usage to have correct/consistent option names

### DIFF
--- a/main.go
+++ b/main.go
@@ -676,7 +676,7 @@ func PrintNewProjectUsage() {
     fmt.Println("       The name of the new project.")
     fmt.Println()
     fmt.Println("Options:")
-    fmt.Println("   --dir <parent_directory>")
+    fmt.Println("   --directory <parent_directory>")
     fmt.Println("       The directory where this utility should place the new project.")
     fmt.Println("       Defaults to the current directory.")
     fmt.Println()


### PR DESCRIPTION
Corrected the usage statement for the `new-project` command so that the option names are consistent and reflect the actual options expected by the command.

Fixes #5 